### PR TITLE
Fixing for Rails 4.2

### DIFF
--- a/lib/subdomain-fu.rb
+++ b/lib/subdomain-fu.rb
@@ -3,7 +3,7 @@ require 'subdomain_fu/url_rewriter'
 module SubdomainFu
   class << self
     attr_accessor :config
-    
+
     def config
       self.config = Configuration.new unless @config
       @config
@@ -11,12 +11,12 @@ module SubdomainFu
   end
 
   # The configurable options of Subdomain Fu. Use like so:
-  # 
+  #
   #     SubdomainFu.configure do |config|
   #       config.tld_size = 2
   #       config.preferred_mirror = 'www'
   #     end
-  # 
+  #
   # Available configurations are:
   #
   # <tt>tld_size</tt>: :: The size of the top-level domain. For example, 'localhost' is 0, 'example.com' is 1, and 'example.co.uk' is 2.
@@ -27,27 +27,27 @@ module SubdomainFu
     self.config ||= Configuration.new
     yield(self.config)
   end
-  
+
   class Configuration
     attr_accessor :tld_sizes, :mirrors, :preferred_mirror, :override_only_path
-    
+
     @@defaults = {
       :tld_sizes => {:development => 1, :test => 1, :production => 1},
       :mirrors => %w(www),
       :preferred_mirror => nil,
       :override_only_path => false
     }
-    
+
     def initialize
       @@defaults.each_pair do |k, v|
         self.send("#{k}=", v)
       end
     end
-    
+
     def tld_size=(size)
       tld_sizes[Rails.env.to_sym] = size
     end
-    
+
     def tld_size
       tld_sizes[Rails.env.to_sym]
     end
@@ -161,7 +161,7 @@ module SubdomainFu
   def self.current_domain(request)
     domain = ""
     domain << request.subdomains[1..-1].join(".") + "." if request.subdomains.length > 1
-    domain << request.domain + request.port_string
+    domain << request.domain.to_s + request.port_string
   end
 
   module Controller

--- a/lib/subdomain_fu/url_rewriter.rb
+++ b/lib/subdomain_fu/url_rewriter.rb
@@ -3,13 +3,13 @@ require 'action_dispatch/routing/route_set'
 module ActionDispatch
   module Routing
     class RouteSet #:nodoc:
-      def url_for_with_subdomains(options, path_segments=nil)
+      def url_for_with_subdomains(options, *args)
         if SubdomainFu.needs_rewrite?(options[:subdomain], options[:host]) || options[:only_path] == false
           options[:only_path] = false if SubdomainFu.override_only_path?
           options[:host] = SubdomainFu.rewrite_host_for_subdomains(options[:subdomain], options[:host])
         end
         options.delete(:subdomain) if (route_name = options[:use_route]) && (route = named_routes.get(route_name)) && route.requirements[:subdomain].blank?
-        url_for_without_subdomains(options)
+        url_for_without_subdomains(options, *args)
       end
       alias_method_chain :url_for, :subdomains
     end


### PR DESCRIPTION
Rails 4.2 changed how `UrlHelper` works in this commit:
https://github.com/rails/rails/commit/212057b912627b9c4056f911a43c83b18ae3ab34